### PR TITLE
prep deps

### DIFF
--- a/rust/thund_delta/Cargo.toml
+++ b/rust/thund_delta/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2021"
 crate-type = ["dylib"]
 
 [dependencies]
+deltalake ="0.4.0"
+arrow2_convert ="0.3.2"
+arrow2_convert_derive = "0.3.2"
 arrowalloy = "0.0.3"
 arrow2 = "0.14.2"
 chrono = "0.4.22"


### PR DESCRIPTION
ok I realized that since we use the excellent arrow2 package it needs to  be type-wise converted to arrow , since delta.rs is based on arrow and not arrow2.




I pushed the deps :) and are reading the docs for https://crates.io/crates/arrow2_convert ..
after getting the arrow type .. the next step is to actually use delta writer ... for thund_delta alloy module